### PR TITLE
Don't specify a aliasing type

### DIFF
--- a/terminal-profile.json
+++ b/terminal-profile.json
@@ -1,7 +1,6 @@
 {
   "profiles": [
     {
-      "antialiasingMode": "aliased",
       "fontWeight": "bold",
       "colorScheme": "Gentoo"
     }


### PR DESCRIPTION
Most windows users are going to want ClearType here, which I'd assume/hope it's a default.